### PR TITLE
update the "Reporting in!" url to point to the current repository.

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -105,7 +105,7 @@ func init() {
 	botCommands["bots"] = &botCommand{
 		false,
 		func(who, arg, nick string) {
-			sendMessage(who, "Reporting in! [ "+colorString("Go!", Cyan)+" ] https://github.com/generaltso/tsobot")
+			sendMessage(who, "Reporting in! [ "+colorString("Go!", Cyan)+" ] https://github.com/dayvonjersen/tsobot")
 		},
 	}
 	botCommands["join"] = &botCommand{


### PR DESCRIPTION
```sh
[12:56:09]   Dionysus: .bots
[12:56:09]     tsobot: Reporting in! [ Go! ] https://github.com/generaltso/tsobot
```
the link does redirect to this repo as the time of writing but the `generaltso` nick seems to be taken, could be a problem once the owner of that account creates a repository called `tsobot`.